### PR TITLE
[Backend] feat: 메인 페이지 - 알림 리스트 API

### DIFF
--- a/backend/src/main/java/com/example/backend/dashboard/controller/AlarmListController.java
+++ b/backend/src/main/java/com/example/backend/dashboard/controller/AlarmListController.java
@@ -29,6 +29,19 @@ public class AlarmListController {
         return ResponseEntity.ok(alarms);
     }
 
+    // case_info id 값으로 상세 조회 (officeId가 동일한 데이터만)
+    @GetMapping("/ready/{id}")
+    public ResponseEntity<?> getCaseById(@PathVariable Integer id, HttpSession session) {
+        UserResponseDto user = (UserResponseDto) session.getAttribute("user");
+
+        if (user == null) {
+            return ResponseEntity.status(403).body("로그인이 필요합니다.");
+        }
+        Integer officeId = user.getOfficeId();
+        AlarmResponse alarm = alarmListService.getCaseById(id, officeId);
+        return ResponseEntity.ok(alarm);
+    }
+
 
 
 }

--- a/backend/src/main/java/com/example/backend/dashboard/controller/AlarmListController.java
+++ b/backend/src/main/java/com/example/backend/dashboard/controller/AlarmListController.java
@@ -1,0 +1,34 @@
+package com.example.backend.dashboard.controller;
+
+import com.example.backend.dashboard.dto.AlarmResponse;
+import com.example.backend.dashboard.service.AlarmListService;
+import com.example.backend.user.dto.UserResponseDto;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/case")
+@RequiredArgsConstructor
+public class AlarmListController {
+    private final AlarmListService alarmListService;
+
+    @GetMapping("/ready")
+    public ResponseEntity<?> getReadyAlarmList(HttpSession session) {
+        UserResponseDto user = (UserResponseDto) session.getAttribute("user");
+
+        if (user == null) {
+            return ResponseEntity.status(403).body("로그인이 필요합니다.");
+        }
+
+        Integer officeId = user.getOfficeId();
+        List<AlarmResponse> alarms = alarmListService.getReadyCases(officeId);
+        return ResponseEntity.ok(alarms);
+    }
+
+
+
+}

--- a/backend/src/main/java/com/example/backend/dashboard/controller/AlarmListController.java
+++ b/backend/src/main/java/com/example/backend/dashboard/controller/AlarmListController.java
@@ -42,6 +42,16 @@ public class AlarmListController {
         return ResponseEntity.ok(alarm);
     }
 
-
+    // 출동 | 미출동 클릭 시 => 1. 이미 출동인 상태 or 2. state를 업데이트
+    @PutMapping("/ready/{id}")
+    public ResponseEntity<?> updateCaseState(@PathVariable Integer id, HttpSession session) {
+        UserResponseDto user = (UserResponseDto) session.getAttribute("user");
+        if (user == null) {
+            return ResponseEntity.status(403).body("로그인이 필요합니다.");
+        }
+        Integer officeId = user.getOfficeId();
+        String message = alarmListService.updateCaseState(id, officeId);
+        return ResponseEntity.ok(message);
+    }
 
 }

--- a/backend/src/main/java/com/example/backend/dashboard/dto/AlarmResponse.java
+++ b/backend/src/main/java/com/example/backend/dashboard/dto/AlarmResponse.java
@@ -1,0 +1,37 @@
+package com.example.backend.dashboard.dto;
+
+import com.example.backend.dashboard.domain.CaseEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AlarmResponse {
+    private Integer id;
+    private Integer officeId;
+    private Integer cctvId;
+    private String location;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime date;
+
+    private Integer level;
+    private String category;
+    private String state;
+
+    public static AlarmResponse fromEntity(CaseEntity entity) {
+        return AlarmResponse.builder()
+                .id(entity.getId())
+                .officeId(entity.getOffice() != null ? entity.getOffice().getId() : null)
+                .cctvId(entity.getCctv() != null ? entity.getCctv().getId() : null)
+                .location(entity.getCctv() != null ? entity.getCctv().getAddress() : null)
+                .date(entity.getDate())
+                .level(entity.getLevel())
+                .category(entity.getCategory().name())
+                .state(entity.getState().name())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/backend/dashboard/dto/AlarmResponse.java
+++ b/backend/src/main/java/com/example/backend/dashboard/dto/AlarmResponse.java
@@ -2,6 +2,7 @@ package com.example.backend.dashboard.dto;
 
 import com.example.backend.dashboard.domain.CaseEntity;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AlarmResponse {
     private Integer id;
     private Integer officeId;
@@ -20,6 +22,7 @@ public class AlarmResponse {
 
     private Integer level;
     private String category;
+    private String video;
     private String state;
 
     public static AlarmResponse fromEntity(CaseEntity entity) {
@@ -34,4 +37,19 @@ public class AlarmResponse {
                 .state(entity.getState().name())
                 .build();
     }
+
+    public static AlarmResponse fromEntityWithVideo(CaseEntity entity) {
+        return AlarmResponse.builder()
+                .id(entity.getId())
+                .officeId(entity.getOffice() != null ? entity.getOffice().getId() : null)
+                .cctvId(entity.getCctv() != null ? entity.getCctv().getId() : null)
+                .location(entity.getCctv() != null ? entity.getCctv().getAddress() : null)
+                .date(entity.getDate())
+                .level(entity.getLevel())
+                .category(entity.getCategory().name())
+                .video(entity.getVideo())
+                .state(entity.getState().name())
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/dashboard/repository/AlarmListRepository.java
+++ b/backend/src/main/java/com/example/backend/dashboard/repository/AlarmListRepository.java
@@ -5,7 +5,9 @@ import com.example.backend.dashboard.domain.CaseEntity.CaseState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AlarmListRepository extends JpaRepository<CaseEntity, Integer> {
     List<CaseEntity> findByOffice_IdAndStateIn(Integer officeId, List<CaseState> states);
+    Optional<CaseEntity> findByIdAndOffice_Id(Integer id, Integer officeId);
 }

--- a/backend/src/main/java/com/example/backend/dashboard/repository/AlarmListRepository.java
+++ b/backend/src/main/java/com/example/backend/dashboard/repository/AlarmListRepository.java
@@ -1,0 +1,11 @@
+package com.example.backend.dashboard.repository;
+
+import com.example.backend.dashboard.domain.CaseEntity;
+import com.example.backend.dashboard.domain.CaseEntity.CaseState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AlarmListRepository extends JpaRepository<CaseEntity, Integer> {
+    List<CaseEntity> findByOffice_IdAndStateIn(Integer officeId, List<CaseState> states);
+}

--- a/backend/src/main/java/com/example/backend/dashboard/service/AlarmListService.java
+++ b/backend/src/main/java/com/example/backend/dashboard/service/AlarmListService.java
@@ -28,4 +28,10 @@ public class AlarmListService {
                 .collect(Collectors.toList());
     }
 
+    public AlarmResponse getCaseById(Integer id, Integer officeId) {
+        CaseEntity caseEntity = alarmListRepository.findByIdAndOffice_Id(id, officeId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사건이 존재하지 않거나, 접근 권한이 없습니다."));
+        return AlarmResponse.fromEntityWithVideo(caseEntity);
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/dashboard/service/AlarmListService.java
+++ b/backend/src/main/java/com/example/backend/dashboard/service/AlarmListService.java
@@ -34,4 +34,19 @@ public class AlarmListService {
         return AlarmResponse.fromEntityWithVideo(caseEntity);
     }
 
+    public String updateCaseState(Integer id, Integer officeId) {
+        CaseEntity caseEntity = alarmListRepository.findByIdAndOffice_Id(id, officeId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사건이 존재하지 않거나, 접근 권한이 없습니다."));
+
+        // 이미 state가 "출동"이면 메시지 반환
+        if (caseEntity.getState() == CaseEntity.CaseState.출동) {
+            return "이미 출동된 사건입니다.";
+        } else {
+            // 그 외의 경우, state를 "출동"으로 변경 후 저장
+            caseEntity.setState(CaseEntity.CaseState.출동);
+            alarmListRepository.save(caseEntity);
+            return "지금 출동합니다.";
+        }
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/dashboard/service/AlarmListService.java
+++ b/backend/src/main/java/com/example/backend/dashboard/service/AlarmListService.java
@@ -1,0 +1,31 @@
+package com.example.backend.dashboard.service;
+
+import com.example.backend.dashboard.domain.CaseEntity;
+import com.example.backend.dashboard.dto.AlarmResponse;
+import com.example.backend.dashboard.repository.AlarmListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.backend.dashboard.domain.CaseEntity.CaseState;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmListService {
+    private final AlarmListRepository alarmListRepository;
+
+    public List<AlarmResponse> getReadyCases(Integer officeId) {
+        List<CaseEntity> cases = alarmListRepository.findByOffice_IdAndStateIn(
+                officeId,
+                Arrays.asList(CaseState.확인, CaseState.미확인)
+        );
+
+        return cases.stream()
+                .map(AlarmResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
## Summary 📝
<!-- 간단한 요약내용을 써주세요 -->
메인페이지 - 알림 리스트 관련 API

- 전체 리스트 가져오기
- 각 알림 자세히 보기 (영상)
- 출동 여부 확인 및 state 출동으로 변경

## Issue Number 🔥
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

- #48 

## To Reviewers 📢
<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
기존 로직이랑 controller, service 분리했습니다

원래 출동 여부 확인 API, 출동 state 변경 API가 각각 있었는데
백에서 한 번에 처리하는게 나을거 같아서 엔드포인트 하나로 합쳤습니다.
노션에 자세히 적었습니다!