### PR TITLE
[Backend] fix: 지도용 장소별 사건 수 API 응답 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/analysis/controller/CaseStatsController.java
+++ b/backend/src/main/java/com/example/backend/analysis/controller/CaseStatsController.java
@@ -1,10 +1,6 @@
 package com.example.backend.analysis.controller;
 
-import com.example.backend.analysis.dto.CaseStatsOverviewResponse;
-import com.example.backend.analysis.dto.DailyCaseStatsResponse;
-import com.example.backend.analysis.dto.HourlyCaseStatsResponse;
-import com.example.backend.analysis.dto.MonthlyCaseStatsResponse;
-import com.example.backend.analysis.dto.CctvCaseStatsResponse;
+import com.example.backend.analysis.dto.*;
 import com.example.backend.analysis.service.CaseStatsService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -98,7 +94,7 @@ public class CaseStatsController {
     @GetMapping("/location")
     public ResponseEntity<?> getLocationCaseStats(@RequestParam("period") String period, HttpSession session) {
         try {
-            List<CctvCaseStatsResponse> stats = caseStatsService.getLocationCaseStats(period, session);
+            List<LocationCaseStatsResponse> stats = caseStatsService.getLocationCaseStats(period, session);
             return ResponseEntity.ok(stats);
         } catch (IllegalStateException e) {
             return ResponseEntity.status(401).body(Collections.singletonMap("message", e.getMessage()));
@@ -115,7 +111,7 @@ public class CaseStatsController {
     @GetMapping("/map")
     public ResponseEntity<?> getMapCaseStats(@RequestParam("period") String period, HttpSession session) {
         try {
-            List<CctvCaseStatsResponse> stats = caseStatsService.getMapCaseStats(period, session);
+            List<MapCaseStatsResponse> stats = caseStatsService.getMapCaseStats(period, session);
             return ResponseEntity.ok(stats);
         } catch (IllegalStateException e) {
             return ResponseEntity.status(401).body(Collections.singletonMap("message", e.getMessage()));

--- a/backend/src/main/java/com/example/backend/analysis/domain/CctvEntity.java
+++ b/backend/src/main/java/com/example/backend/analysis/domain/CctvEntity.java
@@ -22,7 +22,7 @@ public class CctvEntity {
     @Column(name = "longitude", nullable = false)
     private Double longitude;
 
-    @Column(name = "address")
+    @Column(name = "address", nullable = false, columnDefinition = "TEXT")
     private String address;
 
 }

--- a/backend/src/main/java/com/example/backend/analysis/dto/LocationCaseStatsResponse.java
+++ b/backend/src/main/java/com/example/backend/analysis/dto/LocationCaseStatsResponse.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 @Data
 @AllArgsConstructor
-public class CctvCaseStatsResponse {
+public class LocationCaseStatsResponse {
     String address;
     double latitude;
     double longitude;

--- a/backend/src/main/java/com/example/backend/analysis/dto/MapCaseStatsResponse.java
+++ b/backend/src/main/java/com/example/backend/analysis/dto/MapCaseStatsResponse.java
@@ -1,0 +1,17 @@
+package com.example.backend.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MapCaseStatsResponse {
+    String address;
+    double latitude;
+    double longitude;
+    int fire_count;
+    int assault_count;
+    int crowd_congestion_count;
+    int weapon_count;
+    int swoon_count;
+}

--- a/backend/src/main/java/com/example/backend/analysis/repository/CaseStatsCategoryRepository.java
+++ b/backend/src/main/java/com/example/backend/analysis/repository/CaseStatsCategoryRepository.java
@@ -109,17 +109,18 @@ public interface CaseStatsCategoryRepository extends JpaRepository<CaseStatsCate
     List<Object[]> findLocationCaseStats(@Param("startDate") LocalDateTime startDate, @Param("officeId") int officeId);
 
     @Query(value = """
-        SELECT cv.address, cv.latitude, cv.longitude, SUM(sub.total) AS total
-        FROM (
-            SELECT c.cctv_id, SUM(c.fire_count + c.assult_count + c.swoon_count + c.weapon_count + c.crowd_congestion_count) AS total
-            FROM case_stats_category c
-            WHERE c.date >= :startDate
-            GROUP BY c.cctv_id
-        ) AS sub
-        JOIN cctv_info cv ON sub.cctv_id = cv.id
+        SELECT cv.address, cv.latitude, cv.longitude,
+               SUM(c.fire_count) AS fire,
+               SUM(c.assult_count) AS assault,
+               SUM(c.swoon_count) AS swoon,
+               SUM(c.weapon_count) AS weapon,
+               SUM(c.crowd_congestion_count) AS crowd_congestion
+        FROM case_stats_category c
+        JOIN cctv_info cv ON c.cctv_id = cv.id
+        WHERE c.date >= :startDate
         GROUP BY cv.address, cv.latitude, cv.longitude
-        ORDER BY total DESC
+        ORDER BY (SUM(c.fire_count) + SUM(c.assult_count) + SUM(c.swoon_count) + SUM(c.weapon_count) + SUM(c.crowd_congestion_count)) DESC
         """, nativeQuery = true)
-    List<Object[]> findMapCaseStats(@Param("startDate") LocalDateTime startDate, @Param("officeId") int officeId);
+    List<Object[]> findMapCaseStats(@Param("startDate") LocalDateTime startDate);
 
 }

--- a/backend/src/main/java/com/example/backend/analysis/service/CaseStatsService.java
+++ b/backend/src/main/java/com/example/backend/analysis/service/CaseStatsService.java
@@ -1,11 +1,7 @@
 package com.example.backend.analysis.service;
 
 import com.example.backend.analysis.domain.CaseStatsOverviewEntity;
-import com.example.backend.analysis.dto.CaseStatsOverviewResponse;
-import com.example.backend.analysis.dto.DailyCaseStatsResponse;
-import com.example.backend.analysis.dto.HourlyCaseStatsResponse;
-import com.example.backend.analysis.dto.MonthlyCaseStatsResponse;
-import com.example.backend.analysis.dto.CctvCaseStatsResponse;
+import com.example.backend.analysis.dto.*;
 import com.example.backend.analysis.repository.CaseStatsCategoryRepository;
 import com.example.backend.analysis.repository.CaseStatsOverviewRepository;
 import com.example.backend.user.dto.UserResponseDto;
@@ -202,7 +198,7 @@ public class CaseStatsService {
     }
 
     // 장소별 사건 수 조회 (startDate를 계산해 전달)
-    public List<CctvCaseStatsResponse> getLocationCaseStats(String period, HttpSession session) {
+    public List<LocationCaseStatsResponse> getLocationCaseStats(String period, HttpSession session) {
         int officeId = getOfficeId(session);
 
         LocalDateTime startDate = getStartDateFromPeriod(period);
@@ -213,7 +209,7 @@ public class CaseStatsService {
         }
 
         return results.stream()
-                .map(row -> new CctvCaseStatsResponse(
+                .map(row -> new LocationCaseStatsResponse(
                         (String) row[0], // address
                         (Double) row[1], // latitude
                         (Double) row[2], // longitude
@@ -222,22 +218,26 @@ public class CaseStatsService {
     }
 
     // 지도용 장소별 사건 수 조회 (startDate를 계산해 전달)
-    public List<CctvCaseStatsResponse> getMapCaseStats(String period, HttpSession session) {
+    public List<MapCaseStatsResponse> getMapCaseStats(String period, HttpSession session) {
         int officeId = getOfficeId(session);
 
         LocalDateTime startDate = getStartDateFromPeriod(period);
-        List<Object[]> results = statsCategoryRepository.findMapCaseStats(startDate, officeId);
+        List<Object[]> results = statsCategoryRepository.findMapCaseStats(startDate);
 
         if (results.isEmpty()) {
             throw new NoSuchElementException("해당 기간에 대한 장소별 사건 데이터가 없습니다.");
         }
 
         return results.stream()
-                .map(row -> new CctvCaseStatsResponse(
+                .map(row -> new MapCaseStatsResponse(
                         (String) row[0], // address
                         (Double) row[1], // latitude
                         (Double) row[2], // longitude
-                        ((Number) row[3]).intValue())) // count
+                        ((Number) row[3]).intValue(), // fire_count
+                        ((Number) row[4]).intValue(),  // assault_count
+                        ((Number) row[5]).intValue(),  // crowd_congestion_count
+                        ((Number) row[6]).intValue(),  // weapon_count
+                        ((Number) row[7]).intValue())) // swoon_count
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Summary 📝
<!-- 간단한 요약내용을 써주세요 -->
기존 지도용 API 에서 사건의 총합만 반환하던 것을 각 카테고리 별 사건 수 반환으로 수정

## Issue Number 🔥
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

- #57 

## To Reviewers 📢
<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
프론트 요구사항대로 사건의 총합 대신 각 카테고리별 사건 수로 응답을 수정했습니다. 확인 부탁드려요~!