### PR TITLE
[Backend] fix: User API에 police info 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/dashboard/dto/AlarmResponse.java
+++ b/backend/src/main/java/com/example/backend/dashboard/dto/AlarmResponse.java
@@ -15,7 +15,7 @@ public class AlarmResponse {
     private Integer id;
     private Integer officeId;
     private Integer cctvId;
-    private String location;
+    private String address;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime date;
@@ -30,7 +30,7 @@ public class AlarmResponse {
                 .id(entity.getId())
                 .officeId(entity.getOffice() != null ? entity.getOffice().getId() : null)
                 .cctvId(entity.getCctv() != null ? entity.getCctv().getId() : null)
-                .location(entity.getCctv() != null ? entity.getCctv().getAddress() : null)
+                .address(entity.getCctv() != null ? entity.getCctv().getAddress() : null)
                 .date(entity.getDate())
                 .level(entity.getLevel())
                 .category(entity.getCategory().name())
@@ -43,7 +43,7 @@ public class AlarmResponse {
                 .id(entity.getId())
                 .officeId(entity.getOffice() != null ? entity.getOffice().getId() : null)
                 .cctvId(entity.getCctv() != null ? entity.getCctv().getId() : null)
-                .location(entity.getCctv() != null ? entity.getCctv().getAddress() : null)
+                .address(entity.getCctv() != null ? entity.getCctv().getAddress() : null)
                 .date(entity.getDate())
                 .level(entity.getLevel())
                 .category(entity.getCategory().name())

--- a/backend/src/main/java/com/example/backend/dashboard/dto/ProgressResponse.java
+++ b/backend/src/main/java/com/example/backend/dashboard/dto/ProgressResponse.java
@@ -14,7 +14,7 @@ public class ProgressResponse {
     private Integer id;
     private String police_name;
     private String police_rank;
-    private String cctv_address;
+    private String address;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime date;
@@ -30,7 +30,7 @@ public class ProgressResponse {
                 .id(entity.getId())
                 .police_name(entity.getPolice().getName())
                 .police_rank(String.valueOf(entity.getPolice().getRank()))
-                .cctv_address(entity.getCctv().getAddress())
+                .address(entity.getCctv().getAddress())
                 .date(entity.getDate())
                 .level(entity.getLevel())
                 .category(entity.getCategory())

--- a/backend/src/main/java/com/example/backend/user/dto/UserResponseDto.java
+++ b/backend/src/main/java/com/example/backend/user/dto/UserResponseDto.java
@@ -1,13 +1,26 @@
 package com.example.backend.user.dto;
 
+import com.example.backend.common.domain.PoliceEntity;
+import com.example.backend.common.domain.PoliceEntity.police_rank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class UserResponseDto {
-    private Integer id;
     private Integer officeId;
     private String name;
+    private String officeName;
     private String profileUrl;
+    private police_rank rank;
+
+    public static UserResponseDto fromEntity(PoliceEntity police) {
+        return new UserResponseDto(
+                police.getOffice().getId(),
+                police.getName(),
+                police.getOffice().getName(),
+                police.getProfileUrl(),
+                police.getRank()
+        );
+    }
 }

--- a/backend/src/main/java/com/example/backend/user/dto/UserResponseDto.java
+++ b/backend/src/main/java/com/example/backend/user/dto/UserResponseDto.java
@@ -2,12 +2,15 @@ package com.example.backend.user.dto;
 
 import com.example.backend.common.domain.PoliceEntity;
 import com.example.backend.common.domain.PoliceEntity.police_rank;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class UserResponseDto {
+    @JsonIgnore
+    private Integer id;
     private Integer officeId;
     private String name;
     private String officeName;
@@ -16,6 +19,7 @@ public class UserResponseDto {
 
     public static UserResponseDto fromEntity(PoliceEntity police) {
         return new UserResponseDto(
+                police.getId(),
                 police.getOffice().getId(),
                 police.getName(),
                 police.getOffice().getName(),

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -27,8 +27,8 @@ public class UserService {
         Optional<PoliceEntity> user = userRepository.findByUserIdAndPassword(requestDto.getUserId(), requestDto.getPassword());
 
         // 조회한 결과가 있으면 UserResponseDto 객체로 변환하여 반환하고, 없으면 예외 던짐
-        return user.map(value -> new UserResponseDto(value.getId(), value.getOffice().getId(), value.getName(), value.getProfileUrl()))  // 사용자 이름을 포함한 응답 생성
-                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));  // 사용자 정보가 없으면 예외 처리
+        return user.map(UserResponseDto::fromEntity)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
     }
 
 }


### PR DESCRIPTION
## Summary 📝
<!-- 간단한 요약내용을 써주세요 -->
프론트엔드 요구사항에 맞춰서 사이드바에 누락된 사용자 정보를 추가했습니다
- officeName
- rank
- @ JsonIgnore user id

+전체 알림 리스트와 출동중인 사건 주소 형식 통일했습니다.

## Issue Number 🔥
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

- #80 

## To Reviewers 📢
<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
getAuthenticatedPoliceId(HttpSession session)으로 인해 UserResponseDto에 사용자 id가 있어야하는데 
클라이언트에게는 숨겨야하므로, 프론트엔드에는 전송하지 않기위해 @ JsonIgnore 처리했습니다.