### PR TITLE
[Backend] feat: S3 video 인증 로직 추가(Presigned URL)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -57,6 +57,10 @@ jobs:
           SPRING_DATASOURCE_PASSWORD: testpassword
           CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
           CCTV_STREAM_URL_PREFIX: ${{ secrets.CCTV_STREAM_URL_PREFIX }}
+          CLOUD_AWS_BUCKET: ${{secrets.CLOUD_AWS_BUCKET}}
+          CLOUD_AWS_REGION_STATIC: ${{secrets.CLOUD_AWS_REGION_STATIC}}
+          CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{secrets.CLOUD_AWS_CREDENTIALS_ACCESS_KEY}}
+          CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{secrets.CLOUD_AWS_CREDENTIALS_SECRET_KEY}}
         run: ./gradlew test
 
   dependency-submission:
@@ -80,3 +84,4 @@ jobs:
         with:
           gradle-version: '8.12.1'
           build-root-directory: ./backend
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,12 @@ dependencies {
 	// Lombok 의존성 추가
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+	// S3
+	implementation('com.amazonaws:aws-java-sdk-s3:1.12.543') {
+		// 기존 취약한 ion-java 제외하고
+		exclude group: 'software.amazon.ion', module: 'ion-java'
+	}
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/backend/config/S3Config.java
+++ b/backend/src/main/java/com/example/backend/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.example.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider(
+            @Value("${cloud.aws.credentials.access-key}") String accessKey,
+            @Value("${cloud.aws.credentials.secret-key}") String secretKey) {
+        BasicAWSCredentials creds = new BasicAWSCredentials(accessKey, secretKey);
+        return new AWSStaticCredentialsProvider(creds);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(AWSCredentialsProvider awsCredentialsProvider,
+                             @Value("${cloud.aws.region.static}") String region) {
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(awsCredentialsProvider)
+                .withRegion(region)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/backend/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/example/backend/dashboard/service/DashboardService.java
@@ -1,5 +1,7 @@
 package com.example.backend.dashboard.service;
 
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.example.backend.common.domain.CaseEntity;
 import com.example.backend.common.domain.PoliceEntity;
 import com.example.backend.dashboard.dto.DashboardResponse;
@@ -10,20 +12,62 @@ import com.example.backend.user.dto.UserResponseDto;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+
+import com.amazonaws.services.s3.AmazonS3;
+
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class DashboardService {
 
+    @Value("${cloud.aws.bucket}")
+    private String bucket;
+    private final AmazonS3 s3Client;
     private final DashboardRepository dashboardRepository;
+
+
+    public Map<String, String> getCaseVideo(int id, HttpSession session) {
+        CaseEntity caseEntity = getAuthorizedCase(id, session);
+
+        String videoKey = caseEntity.getVideo();
+        if (videoKey == null || videoKey.trim().isEmpty()) {
+            throw new EntityNotFoundException("해당 사건에 대한 영상이 없습니다.");
+        }
+
+        if (caseEntity.getState() == CaseEntity.CaseState.미확인) {
+            caseEntity.setState(CaseEntity.CaseState.확인);
+            dashboardRepository.save(caseEntity);
+        }
+
+        // Presigned URL 유효기간 설정 (30분)
+        Date expiration = new Date();
+        long expTime = expiration.getTime();
+        expTime += TimeUnit.MINUTES.toMillis(30);   // 30 minute
+        expiration.setTime(expTime);
+
+        GeneratePresignedUrlRequest presignRequest =
+                new GeneratePresignedUrlRequest(bucket, videoKey)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration);
+
+        String url = s3Client.generatePresignedUrl(presignRequest).toString();
+        return Collections.singletonMap("video", url);
+
+    }
+
+
+
 
     // 세션에서 officeId 추출
     private int getAuthenticatedOfficeId(HttpSession session) {
@@ -80,22 +124,54 @@ public class DashboardService {
                 .collect(Collectors.toList());
     }
 
-    // id별 사건 영상 확인
-    public Map<String, String> getCaseVideo(int id, HttpSession session) {
-        CaseEntity caseEntity = getAuthorizedCase(id, session);
 
-        String videoUrl = caseEntity.getVideo();
-        if (videoUrl == null || videoUrl.trim().isEmpty()) {
-            throw new EntityNotFoundException("해당 사건에 대한 영상이 없습니다.");
-        }
+//    public Map<String, String> getCaseVideo(int id, HttpSession session) {
+//        CaseEntity caseEntity = getAuthorizedCase(id, session);
+//
+//        String videoUrl = caseEntity.getVideo();
+//        if (videoUrl == null || videoUrl.trim().isEmpty()) {
+//            throw new EntityNotFoundException("해당 사건에 대한 영상이 없습니다.");
+//        }
+//
+//        if (caseEntity.getState() == CaseEntity.CaseState.미확인) {
+//            caseEntity.setState(CaseEntity.CaseState.확인);
+//            dashboardRepository.save(caseEntity);
+//        }
+//        String filename = videoUrl;
+//
+//
+//        Date expiration = new Date();
+//        long expTime = expiration.getTime();
+//        expTime += TimeUnit.MINUTES.toMillis(30);   // 30 minute
+//        expiration.setTime(expTime);
+//
+//        GetPresignedUrlRequest generatePresignedUrlRequest = new GetPresignedUrlRequest(bucket, fileName)
+//                .withMethod(HttpMethod.GET)
+//                .withExpiration(expiration);
+//
+//
+//        return Collections.singletonMap("video", AWSS3ResDto.builder()
+//                .url(s3Presigner.getPresignedUrl(generatePresignedUrlRequest).toString()));
+//    }
+//
 
-        if (caseEntity.getState() == CaseEntity.CaseState.미확인) {
-            caseEntity.setState(CaseEntity.CaseState.확인);
-            dashboardRepository.save(caseEntity);
-        }
 
-        return Collections.singletonMap("video", videoUrl);
-    }
+
+//    public String getPresignedUrl(String originUrl) {
+        // Presigned URL 생성
+
+
+//        GetPresignedUrlRequest getPresignedUrlRequest = s3Presigner.presignGetObject(
+//                req -> req.signatureDuration(Duration.ofMinutes(15)) // 15분 유효기간
+//                        .getObjectRequest(
+//                                GetObjectRequest.builder()
+//                                        .bucket(bucketName)
+//                                        .key(key)
+//                                        .build()
+//                        )
+//        )
+
+//    }
 
     // 출동, 미출동 상태 변경
     public Map<String, String> updateCaseState(int id, StateRequest request, HttpSession session) {

--- a/backend/src/main/java/com/example/backend/search/dto/DetailResponse.java
+++ b/backend/src/main/java/com/example/backend/search/dto/DetailResponse.java
@@ -39,4 +39,11 @@ public class DetailResponse {
                 .memo(entity.getMemo())
                 .build();
     }
+
+    // 오버로드: presignedUrl을 video 필드에 덮어씌워 반환
+    public static DetailResponse fromEntity(CaseEntity e, String presignedUrl) {
+        DetailResponse r = fromEntity(e);
+        r.setVideo(presignedUrl);
+        return r;
+    }
 }

--- a/backend/src/main/java/com/example/backend/search/service/SearchService.java
+++ b/backend/src/main/java/com/example/backend/search/service/SearchService.java
@@ -1,17 +1,23 @@
 package com.example.backend.search.service;
 
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.example.backend.common.domain.CaseEntity;
 import com.example.backend.search.domain.SearchSpecification;
 import com.example.backend.search.dto.*;
 import com.example.backend.search.repository.SearchRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -58,11 +64,29 @@ public class SearchService {
                 .build();
     }
 
+    @Value("${cloud.aws.bucket}")
+    private String bucket;
+    private final AmazonS3 s3Client;
     public DetailResponse getLogById(Integer id) {
         CaseEntity caseEntity = searchRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 로그를 찾을 수 없습니다."));
 
-        return DetailResponse.fromEntity(caseEntity);
+        String videoKey = caseEntity.getVideo();
+
+        // Presigned URL 유효기간 설정 (30분)
+        Date expiration = new Date();
+        long expTime = expiration.getTime();
+        expTime += TimeUnit.MINUTES.toMillis(30);   // 30 minute
+        expiration.setTime(expTime);
+
+        GeneratePresignedUrlRequest presignRequest =
+                new GeneratePresignedUrlRequest(bucket, videoKey)
+                        .withMethod(HttpMethod.GET)
+                        .withExpiration(expiration);
+
+        String presignedUrl = s3Client.generatePresignedUrl(presignRequest).toString();
+
+        return DetailResponse.fromEntity(caseEntity, presignedUrl);
     }
 
 


### PR DESCRIPTION
## Summary 📝
<!-- 간단한 요약내용을 써주세요 -->
S3의 videoKey, 액세스 키, 비밀 액세스 키로 Presigned Url을 발급받는다.
프론트 요청시 인증처리된 URL을 넘겨준다
get /case/{id}
get /log/{id}

## Issue Number 🔥
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

- #160 

## To Reviewers 📢
<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
기존에는 DB video에 비디오 URL을 담았는데, 
로직 상 video에 videoKey(파일/비디오 이름)를 담는 것으로 변경했습니다.