### PR TITLE
[Frontend ]fix: 로그인 타입 오류 해결

### DIFF
--- a/frontend/src/components/Login/LoginCard/LoginForm.tsx
+++ b/frontend/src/components/Login/LoginCard/LoginForm.tsx
@@ -2,7 +2,6 @@ import * as S from './LoginCard.style.ts';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
-import { useProfileStore } from '@/stores/profileStore.ts';
 import { IoWarning } from 'react-icons/io5';
 
 const LoginForm = () => {
@@ -11,18 +10,17 @@ const LoginForm = () => {
   const [isFailed, setIsFailed] = useState<boolean>(false);
   const navigate = useNavigate();
   const { login } = useAuthStore();
-  const { setProfile } = useProfileStore();
 
   const submitLogin = async (e: React.FormEvent) => {
     e.preventDefault();
-    const data = await login(userId, password);
-    if (data !== undefined && 'message' in data) {
+    const result = await login(userId, password);
+
+    if (result === 'fail') {
       setIsFailed(true);
       return;
-    } else if (data !== undefined) {
-      setProfile(() => data);
-      navigate('/monitoring');
     }
+
+    navigate('/monitoring');
   };
 
   return (

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -2,10 +2,11 @@ import { create } from 'zustand';
 import { postLogin, postLogout } from '@/apis/LoginApi';
 import { useProfileStore } from './profileStore';
 import { persist } from 'zustand/middleware';
+import { ProfileType } from '@/types/profile';
 
 interface AuthState {
   isLoggedIn: boolean;
-  login: (userId: string, password: string) => Promise<void>;
+  login: (userId: string, password: string) => Promise<'success' | 'fail'>;
   logout: () => Promise<void>;
   clearAuth: () => void;
 }
@@ -16,9 +17,15 @@ export const useAuthStore = create<AuthState>()(
       isLoggedIn: false,
 
       login: async (userId, password) => {
-        const profile = await postLogin(userId, password);
-        useProfileStore.getState().setProfile(() => profile);
+        const result = await postLogin(userId, password);
+
+        if (result !== undefined && 'message' in result ) {
+          return 'fail';
+        }
+
+        useProfileStore.getState().setProfile(() => result as ProfileType);
         set({ isLoggedIn: true });
+        return 'success';
       },
 
       logout: async () => {
@@ -39,6 +46,6 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
-    }
-  )
+    },
+  ),
 );

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -19,7 +19,7 @@ export const useAuthStore = create<AuthState>()(
       login: async (userId, password) => {
         const result = await postLogin(userId, password);
 
-        if (result !== undefined && 'message' in result ) {
+        if (result !== undefined && 'message' in result) {
           return 'fail';
         }
 


### PR DESCRIPTION
## Summary 📝
<!-- 간단한 요약내용을 써주세요 -->
로그인 타입 오류를 해결했습니다.

## Issue Number 🔥
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

- #173

## To Reviewers 📢
<!-- 리뷰어에게 전달하고 싶은 말을 써주세요 -->
원래는 LoginForm이랑 authStore 각각에서 로그인 요청을 보내고 있었는데(총 2번 보내는 셈)
지금은 authStore에서만 로그인요청을 보내고 로그인 성공,실패 여부를 LoginForm으로 전달하도록 바꾸었습니다.
즉 authStore에서 하는 일은 로그인 요청보내기, 로그인 상태관리, 로그인 성공 실패 여부 전달해주기, 프로필 바꾸기 입니다
LoginForm 에서는 프로필 안다루도록 설정되었어요 (희 말이 맞았음ㅎ)
